### PR TITLE
fix: correct inverted cross-eye stereoscopic projection

### DIFF
--- a/code/mobile/android/PhoneVR/app/src/main/cpp/alvr_main.cpp
+++ b/code/mobile/android/PhoneVR/app/src/main/cpp/alvr_main.cpp
@@ -78,13 +78,20 @@ struct NativeContext {
     std::thread inputThread;
 
     // Une one texture per eye, no need for swapchains.
-    GLuint lobbyTextures[2] = {};
-    GLuint streamTextures[2] = {};
+    GLuint lobbyTextures[2] = {0, 0};
+    GLuint streamTextures[2] = {0, 0};
 
-    float eyeOffsets[2] = {};
+    float eyeOffsets[2] = {0.0, 0.0};
     AlvrFov fovArr[2] = {};
     AlvrViewParams viewParams[2] = {};
     AlvrDeviceMotion deviceMotion = {};
+
+    NativeContext()
+    {
+        memset(&fovArr, 0, (sizeof(fovArr))/sizeof(int));
+        memset(&viewParams, 0, (sizeof(viewParams))/sizeof(int));
+        memset(&deviceMotion, 0, (sizeof(deviceMotion))/sizeof(int));
+    }
 };
 
 NativeContext CTX = {};
@@ -118,9 +125,9 @@ void offsetPosWithQuat(AlvrQuat q, float offset[3], float outPos[3]) {
     float rotatedOffset[3];
     quatVecMultiply(q, offset, rotatedOffset);
 
-    outPos[0] += rotatedOffset[0];
-    outPos[1] += rotatedOffset[1] + FLOOR_HEIGHT;
-    outPos[2] += rotatedOffset[2];
+    outPos[0] -= rotatedOffset[0];
+    outPos[1] -= rotatedOffset[1] - FLOOR_HEIGHT;
+    outPos[2] -= rotatedOffset[2];
 }
 
 AlvrFov getFov(CardboardEye eye) {
@@ -329,8 +336,8 @@ extern "C" JNIEXPORT void JNICALL Java_viritualisres_phonevr_ALVRActivity_render
                 CTX.eyeOffsets[eye] = matrix[12];
             }
 
-            CTX.fovArr[0] = getFov((CardboardEye) 0);
-            CTX.fovArr[1] = getFov((CardboardEye) 1);
+            CTX.fovArr[kLeft] = getFov(kLeft);
+            CTX.fovArr[kRight] = getFov(kRight);
 
             info("renderingParamsChanged, updating new view configs (FOV) to alvr");
             // alvr_send_views_config(fovArr, CTX.eyeOffsets[0] - CTX.eyeOffsets[1]);

--- a/code/mobile/android/PhoneVR/app/src/main/cpp/alvr_main.cpp
+++ b/code/mobile/android/PhoneVR/app/src/main/cpp/alvr_main.cpp
@@ -86,11 +86,10 @@ struct NativeContext {
     AlvrViewParams viewParams[2] = {};
     AlvrDeviceMotion deviceMotion = {};
 
-    NativeContext()
-    {
-        memset(&fovArr, 0, (sizeof(fovArr))/sizeof(int));
-        memset(&viewParams, 0, (sizeof(viewParams))/sizeof(int));
-        memset(&deviceMotion, 0, (sizeof(deviceMotion))/sizeof(int));
+    NativeContext() {
+        memset(&fovArr, 0, (sizeof(fovArr)) / sizeof(int));
+        memset(&viewParams, 0, (sizeof(viewParams)) / sizeof(int));
+        memset(&deviceMotion, 0, (sizeof(deviceMotion)) / sizeof(int));
     }
 };
 


### PR DESCRIPTION
# Pre fix
v20.6 (https://github.com/alvr-org/PhoneVR/pull/286)
![image](https://github.com/alvr-org/PhoneVR/assets/4137788/7a897f2c-6586-4928-813c-8614ccf75b72)

v20.7.1 (notice the bottom lines' distortion inverted)  (https://github.com/alvr-org/PhoneVR/pull/321)
![image](https://github.com/alvr-org/PhoneVR/assets/4137788/22822726-9a82-431c-91e6-15bc036158e6)

# Post fix
![image](https://github.com/alvr-org/PhoneVR/assets/4137788/ff01d1ac-6368-4550-98bf-b544d4839d08)
