### PR TITLE
feat: Add support for x86_64 only systems

### DIFF
--- a/code/mobile/android/PhoneVR/app/CMakeLists.txt
+++ b/code/mobile/android/PhoneVR/app/CMakeLists.txt
@@ -9,45 +9,62 @@ set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS} -O3 -std=c++17 -g")
 set(ANDROID_STL c++_static)
 set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY BOTH)
 
-# find all src files
-file(GLOB_RECURSE  MY_SRC
+file(GLOB_RECURSE LIB_SRC
     ../../../../common/libs/ifaddrs/*.c
     ../../../../common/libs/json/single_include/*.hpp
+)
+
+file(GLOB_RECURSE GVR_SRC
     ../../../../common/src/*.cpp
     ../../../mobile-common/*.cpp
 )
 
-# add my library
-add_library(native-lib SHARED
-    src/main/cpp/native-lib.cpp
+add_library(native-lib-alvr SHARED
     src/main/cpp/alvr_main.cpp
-    ${MY_SRC}
+    ${LIB_SRC}
 )
 
 set(libs_dir ${CMAKE_CURRENT_SOURCE_DIR}/libraries)
 set(alvr_build_dir ${CMAKE_CURRENT_SOURCE_DIR}/../ALVR/build/alvr_client_core)
 
-target_include_directories(native-lib
-    PUBLIC ./libraries/headers
+target_include_directories(native-lib-alvr
     PUBLIC ../../../../common/libs/asio/asio/include
     PUBLIC ../../../../common/libs/eigen/Eigen
     PUBLIC ../../../../common/libs/ifaddrs
     PUBLIC ../../../../common/libs/json/single_include/
-
-    # my headers
-    PUBLIC ../../../../common/src
-    PUBLIC ../../../mobile-common
 
     # ALVR Headers
     PUBLIC ${alvr_build_dir}
     PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../cardboard
 )
 
-target_link_libraries(native-lib
-    log android EGL GLESv3 mediandk OpenMAXAL #todo remove OpenMaxal?
-    # ${CMAKE_CURRENT_SOURCE_DIR}/../../libraries/jni/${ANDROID_ABI}/libgvr.so # TODO: Remove from src tree
+target_link_libraries(native-lib-alvr
+    log android EGL GLESv3 mediandk
     ${alvr_build_dir}/${ANDROID_ABI}/libalvr_client_core.so
     ${libs_dir}/jni/${ANDROID_ABI}/libGfxPluginCardboard.so
-    ${libs_dir}/jni/${ANDROID_ABI}/libgvr.so
-    ${libs_dir}/jni/${ANDROID_ABI}/libgvr_audio.so
 )
+
+IF (NOT "${ANDROID_ABI}" STREQUAL "x86_64")
+    add_library(native-lib-gvr SHARED
+        src/main/cpp/native-lib.cpp
+        ${LIB_SRC}
+        ${GVR_SRC}
+    )
+
+    target_include_directories(native-lib-gvr
+        PUBLIC ./libraries/headers
+        PUBLIC ../../../../common/libs/asio/asio/include
+        PUBLIC ../../../../common/libs/eigen/Eigen
+        PUBLIC ../../../../common/libs/ifaddrs
+        PUBLIC ../../../../common/libs/json/single_include/
+
+        PUBLIC ../../../../common/src
+        PUBLIC ../../../mobile-common
+    )
+
+    target_link_libraries(native-lib-gvr
+        log android EGL GLESv3 mediandk
+        ${libs_dir}/jni/${ANDROID_ABI}/libgvr.so
+        ${libs_dir}/jni/${ANDROID_ABI}/libgvr_audio.so
+    )
+ENDIF ()

--- a/code/mobile/android/PhoneVR/app/build.gradle
+++ b/code/mobile/android/PhoneVR/app/build.gradle
@@ -55,9 +55,6 @@ android {
             }
         }
 
-        //noinspection ChromeOsAbiSupport
-        ndk.abiFilters 'arm64-v8a', 'armeabi-v7a', 'x86'
-
         defaultPublishConfig 'release'
         publishNonDefault true
         archivesBaseName = "PhoneVR-v$versionName"

--- a/code/mobile/android/PhoneVR/app/src/main/cpp/alvr_main.cpp
+++ b/code/mobile/android/PhoneVR/app/src/main/cpp/alvr_main.cpp
@@ -10,7 +10,6 @@
 #include <unistd.h>
 #include <vector>
 
-#include "common.h"
 #include "nlohmann/json.hpp"
 
 using namespace nlohmann;
@@ -187,14 +186,13 @@ void inputThread() {
     }
 }
 
-// extern "C" JNIEXPORT jint JNI_OnLoad(JavaVM *vm, void *) {
-//     CTX.javaVm = vm;
-//     return JNI_VERSION_1_6;
-// }
+ extern "C" JNIEXPORT jint JNI_OnLoad(JavaVM *vm, void *) {
+     CTX.javaVm = vm;
+     return JNI_VERSION_1_6;
+ }
 
 extern "C" JNIEXPORT void JNICALL Java_viritualisres_phonevr_ALVRActivity_initializeNative(
     JNIEnv *env, jobject obj, jint screenWidth, jint screenHeight, jfloat refreshRate) {
-    CTX.javaVm = jVM;
     CTX.javaContext = env->NewGlobalRef(obj);
 
     uint32_t viewWidth = std::max(screenWidth, screenHeight) / 2;

--- a/code/mobile/android/PhoneVR/app/src/main/cpp/alvr_main.cpp
+++ b/code/mobile/android/PhoneVR/app/src/main/cpp/alvr_main.cpp
@@ -186,10 +186,10 @@ void inputThread() {
     }
 }
 
- extern "C" JNIEXPORT jint JNI_OnLoad(JavaVM *vm, void *) {
-     CTX.javaVm = vm;
-     return JNI_VERSION_1_6;
- }
+extern "C" JNIEXPORT jint JNI_OnLoad(JavaVM *vm, void *) {
+    CTX.javaVm = vm;
+    return JNI_VERSION_1_6;
+}
 
 extern "C" JNIEXPORT void JNICALL Java_viritualisres_phonevr_ALVRActivity_initializeNative(
     JNIEnv *env, jobject obj, jint screenWidth, jint screenHeight, jfloat refreshRate) {

--- a/code/mobile/android/PhoneVR/app/src/main/java/viritualisres/phonevr/ALVRActivity.java
+++ b/code/mobile/android/PhoneVR/app/src/main/java/viritualisres/phonevr/ALVRActivity.java
@@ -33,7 +33,7 @@ public class ALVRActivity extends AppCompatActivity
         implements PopupMenu.OnMenuItemClickListener, BatteryLevelListener {
 
     static {
-        System.loadLibrary("native-lib");
+        System.loadLibrary("native-lib-alvr");
     }
 
     private static final String TAG = ALVRActivity.class.getSimpleName() + "-Java";

--- a/code/mobile/android/PhoneVR/app/src/main/java/viritualisres/phonevr/InitActivity.kt
+++ b/code/mobile/android/PhoneVR/app/src/main/java/viritualisres/phonevr/InitActivity.kt
@@ -2,6 +2,7 @@
 package viritualisres.phonevr
 
 import android.content.Intent
+import android.os.Build
 import android.os.Bundle
 import android.text.Html.FROM_HTML_MODE_LEGACY
 import android.text.method.LinkMovementMethod
@@ -9,6 +10,7 @@ import android.text.util.Linkify
 import android.util.Log
 import android.view.View
 import android.widget.TextView
+import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.text.HtmlCompat
 
@@ -40,7 +42,19 @@ class InitActivity : AppCompatActivity() {
     }
 
     fun btOnClickPVRStreamer(view: View) {
-        val intent = Intent(this, MainActivity::class.java)
-        startActivity(intent)
+        // Check if SYSTEM ABI supports other than x86_64 ABI, since libGVR has no support for
+        // x86_64
+        if (Build.SUPPORTED_ABIS.contains("x86") ||
+            Build.SUPPORTED_ABIS.contains("arm64-v8a") ||
+            Build.SUPPORTED_ABIS.contains("armeabi-v7a")) {
+            val intent = Intent(this, MainActivity::class.java)
+            startActivity(intent)
+        } else {
+            Toast.makeText(
+                    this,
+                    "Your device ONLY supports x86_64 ABI, which is not supported by GoogleVR",
+                    Toast.LENGTH_LONG)
+                .show()
+        }
     }
 }

--- a/code/mobile/android/PhoneVR/app/src/main/java/viritualisres/phonevr/MainActivity.kt
+++ b/code/mobile/android/PhoneVR/app/src/main/java/viritualisres/phonevr/MainActivity.kt
@@ -160,7 +160,11 @@ class MainActivity : AppCompatActivity() {
 
     companion object {
         init {
-            System.loadLibrary("native-lib")
+            // check if android supports x86 abi
+            if (Build.SUPPORTED_ABIS.contains("x86") ||
+                Build.SUPPORTED_ABIS.contains("arm64-v8a") ||
+                Build.SUPPORTED_ABIS.contains("armeabi-v7a"))
+                System.loadLibrary("native-lib-gvr")
         }
     }
 }


### PR DESCRIPTION
- remove OpenMAXL
- Separate native-lib-alvr and native-lib-gvr since GVR does not have x86_64 support dont load it runtime
  - very useful especially in AVD Case where from > 30 SDK LEVEL, Google only publishes x86_64 images